### PR TITLE
Fix build error due to missing ANDROIDXENABLED variable

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,6 +33,7 @@
         </config-file>
         <source-file src="src/android/RareloopAppVersion.java" 
                    target-dir="src/com/rareloop/cordova/appversion" />
-        <preference name="AndroidXEnabled" value="true" />
+        <variable name="ANDROIDXENABLED" value="true" />
+        <preference name="AndroidXEnabled" value="$ANDROIDXENABLED" />
     </platform>
 </plugin>


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ksawalha/versioning/pull/2?shareId=1b515f94-7d4b-4508-8305-524d42d608c7).